### PR TITLE
cake_drop now only checks classes in use

### DIFF
--- a/sch_cake.c
+++ b/sch_cake.c
@@ -381,8 +381,9 @@ static unsigned int cake_drop(struct Qdisc *sch)
 	struct cake_fqcd_sched_data *fqcd;
 	struct cake_fqcd_flow *flow;
 
-	/* Queue is full; find the fat flow and drop a packet. */
-	for(j=0; j < CAKE_MAX_CLASSES; j++) {
+	/* Queue is full; check across classes in use
+	 * find the fat flow and drop a packet. */
+	for(j=0; j < q->class_cnt; j++) {
 		fqcd = &q->classes[j];
 
 		list_for_each_entry(flow, &fqcd->old_flows, flowchain) {


### PR DESCRIPTION
Previously cake_drop scanned across all 8 classes (bins) looking for
packets to drop.  Now it only looks across classes in use for a queue.

For a single class instance there will be 7 less iterations around a loop looking in classes that are guaranteed not to have anything in them.  diffserv4 would have 4 less iterations.  cake_clear_class (called from cake_reconfigure) drops all packets in what would be unused classes upon a reconfigure from say 'diffserv8' to 'besteffort'.
