### PR TITLE
Fix kernel version checks

### DIFF
--- a/sch_cake.c
+++ b/sch_cake.c
@@ -221,7 +221,7 @@ enum {
 static inline unsigned int
 cake_hash(struct cake_bin_data *q, const struct sk_buff *skb, int flow_mode)
 {
-#if KERNEL_VERSION(4, 2, 0) >= LINUX_VERSION_CODE
+#if KERNEL_VERSION(4, 2, 0) > LINUX_VERSION_CODE
 	struct flow_keys keys;
 #else
 	struct flow_keys keys, host_keys;
@@ -232,7 +232,7 @@ cake_hash(struct cake_bin_data *q, const struct sk_buff *skb, int flow_mode)
 		     q->flows_cnt < CAKE_SET_WAYS))
 		return 0;
 
-#if  KERNEL_VERSION(4, 2, 0) >= LINUX_VERSION_CODE
+#if  KERNEL_VERSION(4, 2, 0) > LINUX_VERSION_CODE
 	skb_flow_dissect(skb, &keys);
 
 	host_hash = jhash_3words(


### PR DESCRIPTION
New flow dissector in 4.2.0 onwards, not 4.2.1 onward
