### PR TITLE
cake_set_rate ignored passed rtt time

### DIFF
--- a/sch_cake.c
+++ b/sch_cake.c
@@ -805,7 +805,7 @@ static void cake_set_rate(struct cake_bin_data *b, u64 rate, u32 mtu,
 	byte_target_ns = (byte_target * rate_ns) >> rate_shft;
 
 	b->cparams.target = max(byte_target_ns, ns_target);
-	b->cparams.interval = max(MS2TIME(100) +
+	b->cparams.interval = max(rtt_est_ns +
 				     b->cparams.target - ns_target,
 				     b->cparams.target * 8);
 	b->cparams.threshold = (b->cparams.target >> 15) *


### PR DESCRIPTION
cake_set_rate was passed an rtt estimate 'target' time however it
ignored this in preference for a default 100ms.  The passed parameter
happens to be 100ms in all cases....so far!
