### PR TITLE
Enable CAKE NAT support for kernels older than 4.4

### DIFF
--- a/sch_cake.c
+++ b/sch_cake.c
@@ -51,6 +51,7 @@
 #include <net/netlink.h>
 #include <linux/version.h>
 #include "pkt_sched.h"
+#include <linux/if_vlan.h>
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)
 #include <net/flow_keys.h>
 #else
@@ -279,6 +280,12 @@ enum {
 };
 
 #if defined(CONFIG_NF_CONNTRACK) || defined(CONFIG_NF_CONNTRACK_MODULE)
+
+#if KERNEL_VERSION(4, 0, 0) > LINUX_VERSION_CODE
+#define tc_skb_protocol(_skb) \
+(vlan_tx_tag_present(_skb) ? _skb->vlan_proto : _skb->protocol)
+#endif
+
 static inline void cake_update_flowkeys(struct flow_keys *keys, const struct sk_buff *skb)
 {
 	enum ip_conntrack_info ctinfo;

--- a/sch_cake.c
+++ b/sch_cake.c
@@ -60,6 +60,7 @@
 
 #if defined(CONFIG_NF_CONNTRACK) || defined(CONFIG_NF_CONNTRACK_MODULE)
 #include <net/netfilter/nf_conntrack_core.h>
+#include <net/netfilter/nf_conntrack_zones.h>
 #include <net/netfilter/nf_conntrack.h>
 #endif
 

--- a/sch_cake.c
+++ b/sch_cake.c
@@ -318,15 +318,17 @@ static inline void cake_update_flowkeys(struct flow_keys *keys, const struct sk_
 	keys->addrs.v4addrs.dst = ( reverse ? tuple->src.u3.ip : tuple->dst.u3.ip );
 #endif
 
-	if (keys->ports.ports) {
 #if KERNEL_VERSION(4, 2, 0) > LINUX_VERSION_CODE
+	if (keys->ports) {
 		keys->port16[0] = ( reverse ? tuple->dst.u.all : tuple->src.u.all );
 		keys->port16[1] = ( reverse ? tuple->src.u.all : tuple->dst.u.all );
+	}
 #else
+	if (keys->ports.ports) {
 		keys->ports.src = ( reverse ? tuple->dst.u.all : tuple->src.u.all );
 		keys->ports.dst = ( reverse ? tuple->src.u.all : tuple->dst.u.all );
-#endif
 	}
+#endif
 	if (reverse)
 		nf_ct_put(ct);
 	return;

--- a/sch_cake.c
+++ b/sch_cake.c
@@ -306,8 +306,13 @@ static inline void cake_update_flowkeys(struct flow_keys *keys, const struct sk_
 #endif
 			return;
 
+#if KERNEL_VERSION(4, 3, 0) > LINUX_VERSION_CODE
+		hash = nf_conntrack_find_get(dev_net(skb->dev),
+				NF_CT_DEFAULT_ZONE, &srctuple);
+#else
 		hash = nf_conntrack_find_get(dev_net(skb->dev),
 				&nf_ct_zone_dflt, &srctuple);
+#endif
 		if (hash == NULL)
 			return;
 

--- a/sch_cake.c
+++ b/sch_cake.c
@@ -332,7 +332,7 @@ static inline void cake_update_flowkeys(struct flow_keys *keys, const struct sk_
 	return;
 }
 #else
-static inline void cake_update_flowkeys(struct flow_keys *keys, const sk_buff *skb)
+static inline void cake_update_flowkeys(struct flow_keys *keys, const struct sk_buff *skb)
 {
 	/* There is nothing we can do here without CONNTRACK */
 	return;

--- a/sch_cake.c
+++ b/sch_cake.c
@@ -297,8 +297,13 @@ static inline void cake_update_flowkeys(struct flow_keys *keys, const struct sk_
 		const struct nf_conntrack_tuple_hash *hash;
 		struct nf_conntrack_tuple srctuple;
 
+#if KERNEL_VERSION(4, 4, 0) > LINUX_VERSION_CODE
+		if (! nf_ct_get_tuplepr(skb, skb_network_offset(skb),
+					NFPROTO_IPV4, &srctuple))
+#else
 		if (! nf_ct_get_tuplepr(skb, skb_network_offset(skb),
 					NFPROTO_IPV4, dev_net(skb->dev), &srctuple))
+#endif
 			return;
 
 		hash = nf_conntrack_find_get(dev_net(skb->dev),


### PR DESCRIPTION
Fixed several build issues with older kernels while trying to get the latest NAT-aware changes for CAKE working.  I've tested this on Chaos Calmer (kernel 3.18.23) and observed fair bandwidth sharing amongst hosts AND flows, upstream and downstream.  Very cool indeed.
