### PR TITLE
Move #include of codel5_compat.h to cobalt.h, fixes #30

### DIFF
--- a/cobalt.c
+++ b/cobalt.c
@@ -56,10 +56,6 @@
  * more effective on unresponsive flows.
  */
 
-#if KERNEL_VERSION(3, 18, 0) > LINUX_VERSION_CODE
-#include "codel5_compat.h"
-#endif
-
 struct cobalt_skb_cb *get_cobalt_cb(const struct sk_buff *skb)
 {
 	qdisc_cb_private_validate(skb, sizeof(struct cobalt_skb_cb));

--- a/cobalt.h
+++ b/cobalt.h
@@ -58,6 +58,10 @@ typedef s64 cobalt_tdiff_t;
 #define codel_stats_copy_queue(a, b, c, d) gnet_stats_copy_queue(a, b, c, d)
 #define codel_watchdog_schedule_ns(a, b, c) qdisc_watchdog_schedule_ns(a, b, c)
 
+#if KERNEL_VERSION(3, 18, 0) > LINUX_VERSION_CODE
+#include "codel5_compat.h"
+#endif
+
 static inline cobalt_time_t cobalt_get_time(void)
 {
 	return ktime_get_ns();


### PR DESCRIPTION
As mentioned in #30 building sch_cake fails on older kernels (< 3.17) because `ktime_get_ns` didn't exist in those kernels, and codel5_compat.h isn't included in cobalt.h where the function is used. Moving the include from cobalt.c to cobalt.h fixes that.
