### PR TITLE
fix null pointer dereference post 4.8

### DIFF
--- a/sch_cake.c
+++ b/sch_cake.c
@@ -1129,7 +1129,9 @@ retry:
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 8, 0)
 		qdisc_drop(skb, sch);
 #else
-		__qdisc_drop(skb, NULL);
+		//__qdisc_drop(skb, NULL);
+		kfree_skb(skb);
+		qdisc_qstats_drop(sch);
 #endif
 	}
 


### PR DESCRIPTION
Not sure how to get the delayed kfree_skb behaviour so copy pasted the old code for > 4.8.0