### PR TITLE
[RFC] More efficient TCP ACK filtering

### DIFF
--- a/pkt_sched.h
+++ b/pkt_sched.h
@@ -875,7 +875,6 @@ enum {
 	TCA_CAKE_WASH,
 	TCA_CAKE_MPU,
 	TCA_CAKE_INGRESS,
-	TCA_CAKE_ACK_FILTER,
 	__TCA_CAKE_MAX
 };
 #define TCA_CAKE_MAX	(__TCA_CAKE_MAX - 1)
@@ -888,7 +887,7 @@ struct tc_cake_traffic_stats {
 
 #define TC_CAKE_MAX_TINS (8)
 struct tc_cake_xstats {
-	__u16 version;  /* == 5, increments when struct extended */
+	__u16 version;  /* == 4, increments when struct extended */
 	__u8  max_tins; /* == TC_CAKE_MAX_TINS */
 	__u8  tin_cnt;  /* <= TC_CAKE_MAX_TINS */
 
@@ -913,7 +912,6 @@ struct tc_cake_xstats {
 	__u32 capacity_estimate;  /* version 2 */
 	__u32 memory_limit;       /* version 3 */
 	__u32 memory_used;	  /* version 3 */
-	struct tc_cake_traffic_stats ack_drops [TC_CAKE_MAX_TINS]; /* version 5 */
 };
 
 #endif

--- a/pkt_sched.h
+++ b/pkt_sched.h
@@ -875,6 +875,7 @@ enum {
 	TCA_CAKE_WASH,
 	TCA_CAKE_MPU,
 	TCA_CAKE_INGRESS,
+	TCA_CAKE_ACK_FILTER,
 	__TCA_CAKE_MAX
 };
 #define TCA_CAKE_MAX	(__TCA_CAKE_MAX - 1)
@@ -887,7 +888,7 @@ struct tc_cake_traffic_stats {
 
 #define TC_CAKE_MAX_TINS (8)
 struct tc_cake_xstats {
-	__u16 version;  /* == 4, increments when struct extended */
+	__u16 version;  /* == 5, increments when struct extended */
 	__u8  max_tins; /* == TC_CAKE_MAX_TINS */
 	__u8  tin_cnt;  /* <= TC_CAKE_MAX_TINS */
 
@@ -912,6 +913,7 @@ struct tc_cake_xstats {
 	__u32 capacity_estimate;  /* version 2 */
 	__u32 memory_limit;       /* version 3 */
 	__u32 memory_used;	  /* version 3 */
+	struct tc_cake_traffic_stats ack_drops[TC_CAKE_MAX_TINS]; /* v5 */
 };
 
 #endif

--- a/sch_cake.c
+++ b/sch_cake.c
@@ -6,6 +6,7 @@
  * Copyright (C) 2014-2017 Dave Täht <dave+github@taht.net>
  * Copyright (C) 2015-2017 Sebastian Moeller <moeller0@gmx.de>
  * Copyright (C) 2015-2017 Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>
+ * Copyright (C) 2017 Ryan Mounce <ryan@mounce.com.au>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -142,6 +143,7 @@ struct cake_flow {
 	/* this stuff is all needed per-flow at dequeue time */
 	struct sk_buff	  *head;
 	struct sk_buff	  *tail;
+	struct sk_buff	  *ackcheck;
 	struct list_head  flowchain;
 	s32		  deficit;
 	struct cobalt_vars cvars;
@@ -199,6 +201,8 @@ struct cake_tin_data {
 
 	u32	packets;
 	u64	bytes;
+
+	u32	ack_drops;
 
 	/* moving averages */
 	cobalt_time_t avge_delay;
@@ -271,7 +275,8 @@ enum {
 	CAKE_FLAG_PTM = 0x0002,
 	CAKE_FLAG_AUTORATE_INGRESS = 0x0010,
 	CAKE_FLAG_INGRESS = 0x0040,
-	CAKE_FLAG_WASH = 0x0100
+	CAKE_FLAG_WASH = 0x0100,
+	CAKE_FLAG_ACK_FILTER = 0x0200
 };
 
 enum {
@@ -649,6 +654,9 @@ static inline struct sk_buff *dequeue_head(struct cake_flow *flow)
 	if(skb) {
 		flow->head = skb->next;
 		skb->next = NULL;
+
+		if (skb == flow->ackcheck)
+			flow->ackcheck = NULL;
 	}
 
 	return skb;
@@ -665,6 +673,149 @@ flow_queue_add(struct cake_flow *flow, struct sk_buff *skb)
 		flow->tail->next = skb;
 	flow->tail = skb;
 	skb->next = NULL;
+}
+
+static struct sk_buff *ack_filter(struct cake_flow *flow, struct sk_buff *skb)
+{
+	int seglen;
+	struct sk_buff *skb_check, *skb_check_prev, *rogue_ack = NULL;
+	struct iphdr *iph, *iph_check;
+	struct ipv6hdr *ipv6h, *ipv6h_check;
+	struct tcphdr *tcph, *tcph_check;
+
+	/* no other possible ACKs to filter */
+	if (flow->head == skb)
+		return NULL;
+
+	iph = skb->encapsulation ? inner_ip_hdr(skb) : ip_hdr(skb);
+	ipv6h = skb->encapsulation ? inner_ipv6_hdr(skb) : ipv6_hdr(skb);
+
+	/* check that the innermost network header is v4/v6, and contains TCP */
+	if (iph->version == 4) {
+		if (iph->protocol != IPPROTO_TCP)
+			return NULL;
+		seglen = ntohs(iph->tot_len) - (4*iph->ihl);
+		tcph = (struct tcphdr *)((void *)iph + (4*iph->ihl));
+	} else if (ipv6h->version == 6) {
+		if (ipv6h->nexthdr != IPPROTO_TCP)
+			return NULL;
+		seglen = ntohs(ipv6h->payload_len);
+		tcph = (struct tcphdr *)((void *)ipv6h+sizeof(struct ipv6hdr));
+	} else {
+		return NULL;
+	}
+
+	/* the 'triggering' packet need only have the ACK flag set.
+	 * also check that SYN is not set, as there won't be any previous ACKs.
+	 */
+	if ((tcp_flag_word(tcph) &
+		cpu_to_be32(0x00120000)) != TCP_FLAG_ACK)
+		return NULL;
+
+	/* the 'triggering' ACK is at the end of the queue,
+	 * we have already returned if it is the only packet in the flow.
+	 * stop before last packet in queue, don't compare trigger ACK to itself
+	 * start where we finished last time if recorded in ->ackcheck
+	 * otherwise start from the the head of the flow queue.
+	 */
+	skb_check_prev = flow->ackcheck ?: NULL;
+	skb_check = flow->ackcheck ?: flow->head;
+
+	while (skb_check->next) {
+		/* don't increment if at head of flow queue (_prev == NULL) */
+		if (skb_check_prev) {
+			skb_check_prev = skb_check;
+			skb_check = skb_check->next;
+			if (!skb_check->next)
+				break;
+		} else {
+			skb_check_prev = skb_check;
+		}
+
+		iph_check = skb_check->encapsulation ?
+			inner_ip_hdr(skb_check) : ip_hdr(skb_check);
+		ipv6h_check = skb_check->encapsulation ?
+			inner_ipv6_hdr(skb_check) : ipv6_hdr(skb_check);
+
+		if (iph_check->version == 4) {
+			if (iph_check->protocol != IPPROTO_TCP)
+				continue;
+			seglen = ntohs(iph_check->tot_len) - (4*iph_check->ihl);
+			tcph_check = (struct tcphdr *)((void *)iph_check
+				+ (4*iph_check->ihl));
+
+		} else if (ipv6h_check->version == 6) {
+			if (ipv6h_check->nexthdr != IPPROTO_TCP)
+				continue;
+			seglen = ntohs(ipv6h_check->payload_len);
+			tcph_check = (struct tcphdr *)((void *)ipv6h_check
+				+ sizeof(struct ipv6hdr));
+
+		} else {
+			continue;
+		}
+
+		/* stricter criteria apply to ACKs that we may filter
+		 * 3 reserved flags must be unset to avoid future breakage
+		 * ECE/CWR/NS can be safely ignored
+		 * ACK must be set
+		 * All other flags URG/PSH/RST/SYN/FIN must be unset
+		 * must be 'pure' ACK, contain zero bytes of segment data
+		 * options are ignored
+		 */
+		if (((tcp_flag_word(tcph_check) &
+			cpu_to_be32(0x0E3F0000)) != TCP_FLAG_ACK) ||
+		    ((seglen - 4*tcph_check->doff) != 0)) {
+			continue;
+		}
+
+		/* if the hosts or ports don't match, we have found a 'rogue'
+		 * ACK in this flow belonging to a different connection.
+		 * continue checking for other ACKs this round however
+		 * restart checking from the 'rogue' next time.
+		 */
+		if ((tcph_check->source != tcph->source) ||
+		    (tcph_check->dest != tcph->dest) ||
+		    (iph_check->version == 4 && iph->version == 4 &&
+			((iph_check->saddr != iph->saddr) ||
+			 (iph_check->daddr != iph->daddr))) ||
+		    (ipv6h_check->version == 6 && ipv6h->version == 6 &&
+			(ipv6_addr_cmp(&ipv6h_check->saddr, &ipv6h->saddr) ||
+			 ipv6_addr_cmp(&ipv6h_check->daddr, &ipv6h->daddr)))) {
+		/* very minor issue: if a 'rogue' ACK is seen at the head of
+		 * this flow queue it can never be filtered.
+		 * this is unlikely, and harmless.
+		 * solveable by assigning this case a sentinel rogue_ack value
+		 * not worth any extra effort or cpu cycles
+		 */
+			if (!rogue_ack && (skb_check != flow->head))
+				rogue_ack = skb_check_prev;
+			continue;
+		}
+
+		/* new ack sequence must be greater
+		 * equal DupACKs won't be filtered, would break fast retransmit
+		 * SACKs won't be filtered as they look like DupACKs
+		 * they won't be dropped either, safely reverts to unfiltered
+		 * specific handling and filtering of SACKs is possible
+		 * this is left as an exercise for the reader :)
+		 */
+		if (ntohl(tcph_check->ack_seq) >= ntohl(tcph->ack_seq))
+			continue;
+
+		if (skb_check == flow->head) {
+			flow->head = skb_check->next;
+			flow->ackcheck = NULL;
+		} else {
+			skb_check_prev->next = skb_check->next;
+			flow->ackcheck = rogue_ack ?: skb_check_prev;
+		}
+
+		return skb_check;
+	}
+
+	flow->ackcheck = rogue_ack ?: skb_check_prev;
+	return NULL;
 }
 
 static inline u32 cake_overhead(struct cake_sched_data *q, u32 in)
@@ -886,8 +1037,10 @@ static s32 cake_enqueue(struct sk_buff *skb, struct Qdisc *sch, struct sk_buff *
 	u32 idx, tin;
 	struct cake_tin_data *b;
 	struct cake_flow *flow;
-	u32 len = qdisc_pkt_len(skb);
+	/* signed len to handle corner case filtered ACK larger than trigger */
+	int len = qdisc_pkt_len(skb);
 	u64 now = cobalt_get_time();
+	struct sk_buff *skb_filtered_ack = NULL;
 
 	/* extract the Diffserv Precedence field, if it exists */
 	/* and clear DSCP bits if washing */
@@ -937,7 +1090,10 @@ static s32 cake_enqueue(struct sk_buff *skb, struct Qdisc *sch, struct sk_buff *
 	if (skb_is_gso(skb)) {
 		struct sk_buff *segs, *nskb;
 		netdev_features_t features = netif_skb_features(skb);
-		u32 slen = 0;
+		/* signed slen to handle corner case
+		 * suppressed ACK larger than trigger
+		 */
+		int slen = 0;
 		segs = skb_gso_segment(skb, features & ~NETIF_F_GSO_MASK);
 
 		if (IS_ERR_OR_NULL(segs))
@@ -953,14 +1109,26 @@ static s32 cake_enqueue(struct sk_buff *skb, struct Qdisc *sch, struct sk_buff *
 			qdisc_skb_cb(segs)->pkt_len = segs->len;
 			cobalt_set_enqueue_time(segs, now);
 			flow_queue_add(flow, segs);
-			/* stats */
-			sch->q.qlen++;
-			b->packets++;
-			slen += segs->len;
-			q->buffer_used += segs->truesize;
+
+			if (q->rate_flags & CAKE_FLAG_ACK_FILTER)
+				skb_filtered_ack = ack_filter(flow, segs);
+			if (skb_filtered_ack) {
+				b->ack_drops++;
+				slen += segs->len - skb_filtered_ack->len;
+				q->buffer_used += segs->truesize
+					- skb_filtered_ack->truesize;
+				qdisc_tree_reduce_backlog(sch, 1,
+					qdisc_pkt_len(skb_filtered_ack));
+				consume_skb(skb_filtered_ack);
+			} else {
+				sch->q.qlen++;
+				b->packets++;
+				slen += segs->len;
+				q->buffer_used += segs->truesize;
+			}
 			segs = nskb;
 		}
-
+		/* stats */
 		b->bytes	    += slen;
 		b->backlogs[idx]    += slen;
 		b->tin_backlog      += slen;
@@ -974,15 +1142,27 @@ static s32 cake_enqueue(struct sk_buff *skb, struct Qdisc *sch, struct sk_buff *
 		cobalt_set_enqueue_time(skb, now);
 		flow_queue_add(flow, skb);
 
+		if (q->rate_flags & CAKE_FLAG_ACK_FILTER)
+			skb_filtered_ack = ack_filter(flow, skb);
+		if (skb_filtered_ack) {
+			b->ack_drops++;
+			len -= qdisc_pkt_len(skb_filtered_ack);
+			q->buffer_used += skb->truesize
+				- skb_filtered_ack->truesize;
+			qdisc_tree_reduce_backlog(sch, 1,
+				qdisc_pkt_len(skb_filtered_ack));
+			consume_skb(skb_filtered_ack);
+		} else {
+			sch->q.qlen++;
+			b->packets++;
+			q->buffer_used      += skb->truesize;
+		}
 		/* stats */
-		sch->q.qlen++;
-		b->packets++;
 		b->bytes	    += len;
 		b->backlogs[idx]    += len;
 		b->tin_backlog      += len;
 		sch->qstats.backlog += len;
 		q->avg_window_bytes += len;
-		q->buffer_used      += skb->truesize;
 	}
 
 	if(q->overflow_timeout)
@@ -1373,7 +1553,8 @@ static const struct nla_policy cake_policy[TCA_CAKE_MAX + 1] = {
 	[TCA_CAKE_ETHERNET]      = { .type = NLA_U32 },
 	[TCA_CAKE_WASH]		 = { .type = NLA_U32 },
 	[TCA_CAKE_MPU]		 = { .type = NLA_U32 },
-	[TCA_CAKE_INGRESS]		 = { .type = NLA_U32 },
+	[TCA_CAKE_INGRESS]	 = { .type = NLA_U32 },
+	[TCA_CAKE_ACK_FILTER]	 = { .type = NLA_U32 },
 };
 
 static void cake_set_rate(struct cake_tin_data *b, u64 rate, u32 mtu,
@@ -1849,6 +2030,13 @@ static int cake_change(struct Qdisc *sch, struct nlattr *opt)
 			q->rate_flags &= ~CAKE_FLAG_INGRESS;
 	}
 
+	if (tb[TCA_CAKE_ACK_FILTER]) {
+		if (!!nla_get_u32(tb[TCA_CAKE_ACK_FILTER]))
+			q->rate_flags |= CAKE_FLAG_ACK_FILTER;
+		else
+			q->rate_flags &= ~CAKE_FLAG_ACK_FILTER;
+	}
+
 	if (tb[TCA_CAKE_MEMORY])
 		q->buffer_config_limit = nla_get_s32(tb[TCA_CAKE_MEMORY]);
 
@@ -2005,6 +2193,10 @@ static int cake_dump(struct Qdisc *sch, struct sk_buff *skb)
 			!!(q->rate_flags & CAKE_FLAG_INGRESS)))
 		goto nla_put_failure;
 
+	if (nla_put_u32(skb, TCA_CAKE_ACK_FILTER,
+			!!(q->rate_flags & CAKE_FLAG_ACK_FILTER)))
+		goto nla_put_failure;
+
 	if (nla_put_u32(skb, TCA_CAKE_MEMORY, q->buffer_config_limit))
 		goto nla_put_failure;
 
@@ -2026,7 +2218,7 @@ static int cake_dump_stats(struct Qdisc *sch, struct gnet_dump *d)
 
 	BUG_ON(q->tin_cnt > TC_CAKE_MAX_TINS);
 
-	st->version = 4;
+	st->version = 5;
 	st->max_tins = TC_CAKE_MAX_TINS;
 	st->tin_cnt = q->tin_cnt;
 
@@ -2043,6 +2235,7 @@ static int cake_dump_stats(struct Qdisc *sch, struct gnet_dump *d)
 		st->dropped[i].packets    = b->tin_dropped;
 		st->ecn_marked[i].packets = b->tin_ecn_mark;
 		st->backlog[i].bytes      = b->tin_backlog;
+		st->ack_drops[i].packets  = b->ack_drops;
 
 		st->peak_delay_us[i] = cobalt_time_to_us(b->peak_delay);
 		st->avge_delay_us[i] = cobalt_time_to_us(b->avge_delay);


### PR DESCRIPTION
Revision of #63 which was merged sooner than I expected :)

This is beneficial to the upstream of highly asymmetrical links, where
TCP ACKs alone are often enough to saturate the link. ACKs are
cumulative, so it is desirable to queue only the most recent ACK for a
connection at any point in time. This scheme is commonly implemented
within DOCSIS modems.

ACKs with duplicate acknowledgement sequence numbers (DupACKs) should
not be filtered as this interferes with fast retransmit. SACKs should
not be filtered either (without special handling), this patch relies on
the same property of DupACKs that they will have duplicate ack sequence
numbers, and does not implement any special handling of TCP options.
Special handling of SACKs should also be possible in the future.

This routine is triggered on the enqueue of a TCP packet (containing
data or a 'pure' ACK), and scans its corresponding flow queue for 'pure'
ACKs that may be filtered if they are stale and redundant.

Overhead is minimised in the case of an upload (where there may be a
deeper flow queue without any 'pure' ACKs to thin), by saving the point
in the queue that is known to be ACK-free. UDP and other protocols will
not trigger the routine.

ECE/CWR/NS can be safely ignored in ACKs, however 'pure' ACKs with any
other flags set will not be filtered to avoid future breakage.

As ACKs are anti-responsive, filtering only makes sense for egress.

An admittedly somewhat unscientific test indicates huge gains when
tested on a LAN. Bidirectional netcat + pv transfer with upstream shaped
by cake to 300kbps.

without ack filtering:
4MiB/s or 36MiB/s (depending on whether BLUE happens to kick in)
upload 18KiB/s

with ack filtering:
download 71MiB/s
upload 30KiB/s

This is a performance win/win, importantly it is consistent unlike BLUE.
A less aggressive variant that does not drop ACKs from the head of the
queue was also tested and yielded ~75MiB/s down 23KiB/s up. It is
considered that the somewhat more aggressive recovery of bandwidth from
ACKs towards data flows is desirable in most cases with no evident
drawbacks.

Signed-off-by: Ryan Mounce <ryan@mounce.com.au>