### PR TITLE
sch_cake: fix reporting of overhead

### DIFF
--- a/sch_cake.c
+++ b/sch_cake.c
@@ -2155,7 +2155,7 @@ static int cake_change(struct Qdisc *sch, struct nlattr *opt)
 			!!nla_get_u32(tb[TCA_CAKE_NAT]);
 	}
 
-	if (tb[TCA_CAKE_OVERHEAD] && tb[TCA_CAKE_ETHERNET]) {
+	if (tb[TCA_CAKE_OVERHEAD]) {
 		if (tb[TCA_CAKE_ETHERNET])
 			q->rate_overhead = -(nla_get_s32(tb[TCA_CAKE_ETHERNET]));
 		else


### PR DESCRIPTION
Fix reporting of qdisc overhead vs kernel interface overhead.

Tested-on: ar71xx Archer C7 v2 linux 4.9.63

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>