### PR TITLE
sch_cake: make max_skblen u32

### DIFF
--- a/sch_cake.c
+++ b/sch_cake.c
@@ -165,7 +165,7 @@ struct cake_tin_data {
 	u16	decaying_flow_count;
 	u16	unresponsive_flow_count;
 
-	u16	max_skblen;
+	u32	max_skblen;
 
 	struct list_head new_flows;
 	struct list_head old_flows;


### PR DESCRIPTION
It turns out that qdisc_pkt_len(skb) can return packet lengths larger
than 64K which caused occasional wraparound issues when comparing u16
to the returned u32 value.  Keep the max length in a u32.

There's already a u32 in stats reporting structure so no overhead change
there.

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>


I know you hate the stats Dave, ideally what we report should be correct ;-)