### PR TITLE
sch_cake: remove unnecessary includes

### DIFF
--- a/sch_cake.c
+++ b/sch_cake.c
@@ -55,14 +55,12 @@
 #include <linux/version.h>
 #include <net/netlink.h>
 #include <net/pkt_sched.h>
-#include <linux/if_vlan.h>
 #include <net/tcp.h>
 #include <net/flow_dissector.h>
 #include <net/cobalt.h>
 
 #if IS_ENABLED(CONFIG_NF_CONNTRACK)
 #include <net/netfilter/nf_conntrack_core.h>
-#include <net/netfilter/nf_conntrack_zones.h>
 #include <net/netfilter/nf_conntrack.h>
 #endif
 


### PR DESCRIPTION
Both if_vlan.h and nf_conntrack_zones.h were added in PR https://github.com/dtaht/sch_cake/pull/33 to support older kernels. They should be harmless in kernel v4.4 and later but not strictly needed.

Compile tested (out-of-tree cobalt branch) on v4.4 (Ubuntu LTS and LEDE) and net-next.
