### PR TITLE
[RFC] Cleanup and add "standard" module version for upstreaming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ KERNEL_VERSION := $(shell uname -r)
 IDIR := /lib/modules/$(KERNEL_VERSION)/kernel/net/sched/
 KDIR := /lib/modules/$(KERNEL_VERSION)/build
 PWD := $(shell pwd)
-VERSION := $(shell git rev-parse HEAD 2>/dev/null)
+GIT_REV := $(shell git rev-parse HEAD 2>/dev/null)
 default:
-	$(MAKE) -C $(KDIR) SUBDIRS=$(PWD) modules $(if $(VERSION),LDFLAGS_MODULE="--build-id=0x$(VERSION)" CFLAGS_MODULE="-DCAKE_VERSION=\\\"$(VERSION)\\\"")
+	$(MAKE) -C $(KDIR) SUBDIRS=$(PWD) modules $(if $(GIT_REV),LDFLAGS_MODULE="--build-id=0x$(GIT_REV)" CFLAGS_MODULE="-DCAKE_GIT_REVISION=\\\"$(GIT_REV)\\\"")
 
 install:
 	install -v -m 644 sch_cake.ko $(IDIR)

--- a/sch_cake.c
+++ b/sch_cake.c
@@ -1,4 +1,4 @@
-/* COMMON Applications Kept Enhanced (CAKE) discipline - version 5
+/* COMMON Applications Kept Enhanced (CAKE) discipline - stats version 5
  *
  * Copyright (C) 2014-2017 Jonathan Morton <chromatix99@gmail.com>
  * Copyright (C) 2015-2017 Toke Høiland-Jørgensen <toke@toke.dk>
@@ -118,6 +118,10 @@
 #define CAKE_SET_WAYS (8)
 #define CAKE_MAX_TINS (8)
 #define CAKE_QUEUES (1024)
+
+#define CAKE_ABI_VERSION "1.0"
+static char *cake_abi_version __attribute__((used)) = "version="
+		CAKE_ABI_VERSION;
 
 #ifndef CAKE_GIT_REVISION
 #define CAKE_GIT_REVISION "unknown"
@@ -2681,4 +2685,5 @@ module_exit(cake_module_exit)
 MODULE_AUTHOR("Jonathan Morton");
 MODULE_LICENSE("Dual BSD/GPL");
 MODULE_DESCRIPTION("The CAKE queue discipline: deficit-mode shaping, AQM and FQ.");
+MODULE_VERSION(CAKE_ABI_VERSION);
 MODULE_INFO(gitrevision, CAKE_GIT_REVISION);

--- a/sch_cake.c
+++ b/sch_cake.c
@@ -119,11 +119,11 @@
 #define CAKE_MAX_TINS (8)
 #define CAKE_QUEUES (1024)
 
-#ifndef CAKE_VERSION
-#define CAKE_VERSION "unknown"
+#ifndef CAKE_GIT_REVISION
+#define CAKE_GIT_REVISION "unknown"
 #endif
-static char *cake_version __attribute__((used)) = "Cake version: "
-		CAKE_VERSION;
+static char *cake_git_revision __attribute__((used)) = "gitrevision="
+		CAKE_GIT_REVISION;
 
 enum {
 	CAKE_SET_NONE = 0,
@@ -2680,4 +2680,5 @@ module_init(cake_module_init)
 module_exit(cake_module_exit)
 MODULE_AUTHOR("Jonathan Morton");
 MODULE_LICENSE("Dual BSD/GPL");
-MODULE_DESCRIPTION("The Cake shaper. Version: " CAKE_VERSION);
+MODULE_DESCRIPTION("The CAKE queue discipline: deficit-mode shaping, AQM and FQ.");
+MODULE_INFO(gitrevision, CAKE_GIT_REVISION);


### PR DESCRIPTION
With Cake going upstream, and hopefully stabilizing further,  it would be good to have an easily accessible version number for baseline functionality (i.e. a "1.0") and go-forward tracking of ABI changes e.g. new keywords. While this PR targets cobalt, it's intended for upstream too.

A fuller description is in the commits. Compile and run tested on v4.4 under Ubuntu LTS and LEDE.