### PR TITLE
ack_filter: fix TCP flag check

### DIFF
--- a/sch_cake.c
+++ b/sch_cake.c
@@ -1012,7 +1012,7 @@ static struct sk_buff *cake_ack_filter(struct cake_sched_data *q,
 		 * must be 'pure' ACK, contain zero bytes of segment data
 		 * options are ignored
 		 */
-		if ((tcp_flag_word(tcph) &
+		if ((tcp_flag_word(tcph_check) &
 			(TCP_FLAG_ACK | TCP_FLAG_SYN)) != TCP_FLAG_ACK) {
 			continue;
 		} else if (((tcp_flag_word(tcph_check) &


### PR DESCRIPTION
Fixes https://github.com/dtaht/sch_cake/issues/82

SYNs could theoretically have been filtered, which should not happen regardless of how weird the behaviour would be to trigger this case.