### PR TITLE
Improve usability with user tc filters

### DIFF
--- a/sch_cake.c
+++ b/sch_cake.c
@@ -1604,7 +1604,7 @@ static u32 cake_classify(struct Qdisc *sch, struct cake_tin_data **t,
 	struct cake_sched_data *q = qdisc_priv(sch);
 	struct tcf_proto *filter;
 	struct tcf_result res;
-	u32 flow = 0;
+	u32 flow = TC_H_ROOT;
 	int result;
 
 	filter = rcu_dereference_bh(q->filter_list);
@@ -1626,12 +1626,13 @@ static u32 cake_classify(struct Qdisc *sch, struct cake_tin_data **t,
 			return 0;
 		}
 #endif
-		if (TC_H_MIN(res.classid) <= CAKE_QUEUES)
+		if (TC_H_MAJ(res.classid) == sch->handle &&
+		    TC_H_MIN(res.classid) <= CAKE_QUEUES)
 			flow = TC_H_MIN(res.classid);
 	}
 hash:
 	*t = cake_select_tin(sch, skb);
-	return flow ?: cake_hash(*t, skb, flow_mode) + 1;
+	return (flow != TC_H_ROOT) ? flow : cake_hash(*t, skb, flow_mode) + 1;
 }
 
 static void cake_reconfigure(struct Qdisc *sch);

--- a/sch_cake.c
+++ b/sch_cake.c
@@ -3030,3 +3030,11 @@ module_exit(cake_module_exit)
 MODULE_AUTHOR("Jonathan Morton");
 MODULE_LICENSE("Dual BSD/GPL");
 MODULE_DESCRIPTION("The CAKE shaper.");
+
+static unsigned int max_tins = CAKE_MAX_TINS;
+module_param(max_tins, uint, 0444);
+MODULE_PARM_DESC(max_tins, "Maximum number of priority tins available");
+
+static unsigned int max_queues = CAKE_QUEUES;
+module_param(max_queues, uint, 0444);
+MODULE_PARM_DESC(max_queues, "Maximum number of flow queues available");


### PR DESCRIPTION
@tohojo Hi Toke,
I was exploring the tc filter support recently and noticed some of the same issues as you did, before you fixed them :-). However, I think there are a couple more improvements to be made, so please have a look.

BTW are there plans to backport the tcf stuff? Some technical limitation? This would be really handy to have as it helps unify ingress packet mangling across shaping qdiscs.

Thanks,
Tony

p.s. Could you please use my correct name in your [PATCH net-next vXX 1/8] patch submissions? This was fixed before but has crept in yet again. I blame KDB for first using my git handle to make a proper name... 