### PR TITLE
cake: don't wrong skb->mac_len gso fixup on fixed kernels

### DIFF
--- a/sch_cake.c
+++ b/sch_cake.c
@@ -1799,13 +1799,18 @@ static s32 cake_enqueue(struct sk_buff *skb, struct Qdisc *sch,
 			cobalt_set_enqueue_time(segs, now);
 			get_cobalt_cb(segs)->adjusted_len = cake_overhead(q,
 									  segs);
-
+#if !((LINUX_VERSION_CODE >= KERNEL_VERSION(3, 18, 124) && LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0)) || \
+      (LINUX_VERSION_CODE >= KERNEL_VERSION(4,  4, 159) && LINUX_VERSION_CODE < KERNEL_VERSION(4,  5, 0)) || \
+      (LINUX_VERSION_CODE >= KERNEL_VERSION(4,  9, 130) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)) || \
+      (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 14,  73) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)) || \
+      (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 18,  11)))
 			/* For encapsulated packets, the mac_len may not be set
 			 * correctly after GSO split. Fix this by resetting it;
 			 * if skb_gso_segment() already does this correctly,
 			 * this is will just recalculate the current value.
 			 */
 			skb_reset_mac_len(skb);
+#endif
 
 			flow_queue_add(flow, segs);
 


### PR DESCRIPTION
Stable kernels backport the gso fixup fix, so cake
doesn't need to do it.  Let's not waste cpu cycles by doing it in
cake which could be really important on cpu constrained devices.

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>