### PR TITLE
clarify logic & improve readability of select tin

### DIFF
--- a/sch_cake.c
+++ b/sch_cake.c
@@ -1622,10 +1622,12 @@ static void cake_wash_diffserv(struct sk_buff *skb)
 {
 	switch (skb->protocol) {
 	case htons(ETH_P_IP):
-		ipv4_change_dsfield(ip_hdr(skb), INET_ECN_MASK, 0);
+		if (ipv4_get_dsfield(ip_hdr(skb)) & ~INET_ECN_MASK)
+			ipv4_change_dsfield(ip_hdr(skb), INET_ECN_MASK, 0);
 		break;
 	case htons(ETH_P_IPV6):
-		ipv6_change_dsfield(ipv6_hdr(skb), INET_ECN_MASK, 0);
+		if (ipv6_get_dsfield(ipv6_hdr(skb)) & ~INET_ECN_MASK)
+			ipv6_change_dsfield(ipv6_hdr(skb), INET_ECN_MASK, 0);
 		break;
 	default:
 		break;


### PR DESCRIPTION
Existing code structure is difficult to read, also it looks up tc
priority fields for tin selection even if running in a 1 tin only
mode (besteffort)

Refactor code to only do tin look ups in classification modes that
require it.

Clarify to us & compiler that DSCP washing is a boolean do/don't
wash flag and the masked flag value isn't important.

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>