### PR TITLE
sch_cake: properly obtain skb proto in case of VLAN

### DIFF
--- a/cobalt_compat.h
+++ b/cobalt_compat.h
@@ -103,6 +103,13 @@ static inline int skb_try_make_writable(struct sk_buff *skb,
 }
 #endif
 
+#if KERNEL_VERSION(4, 11, 0) > LINUX_VERSION_CODE
+static inline int skb_mac_offset(const struct sk_buff *skb)
+{
+	return skb_mac_header(skb) - skb->data;
+}
+#endif
+
 #if KERNEL_VERSION(4, 7, 0) > LINUX_VERSION_CODE
 #define nla_put_u64_64bit(skb, attrtype, value, padattr) nla_put_u64(skb, attrtype, value)
 #endif

--- a/sch_cake.c
+++ b/sch_cake.c
@@ -595,11 +595,25 @@ static bool cobalt_should_drop(struct cobalt_vars *vars,
 	return drop;
 }
 
+static __be16 cake_skb_proto(const struct sk_buff *skb)
+{
+	unsigned int offset = skb_mac_offset(skb) + sizeof(struct ethhdr);
+	__be16 proto = skb->protocol;
+	struct vlan_hdr vhdr, *vh;
+
+	while (proto == htons(ETH_P_8021Q) || proto == htons(ETH_P_8021AD)) {
+		vh = skb_header_pointer(skb, offset, sizeof(vhdr), &vhdr);
+		if (!vh)
+			break;
+
+		proto = vh->h_vlan_encapsulated_proto;
+		offset += sizeof(vhdr);
+	}
+
+	return proto;
+}
+
 #if IS_REACHABLE(CONFIG_NF_CONNTRACK)
-#if KERNEL_VERSION(4, 0, 0) > LINUX_VERSION_CODE
-#define tc_skb_protocol(_skb) \
-(vlan_tx_tag_present(_skb) ? _skb->vlan_proto : _skb->protocol)
-#endif
 
 static void cake_update_flowkeys(struct flow_keys *keys,
 				 const struct sk_buff *skb)
@@ -609,7 +623,7 @@ static void cake_update_flowkeys(struct flow_keys *keys,
 	struct nf_conn *ct;
 	bool rev = false;
 
-	if (tc_skb_protocol(skb) != htons(ETH_P_IP))
+	if (cake_skb_proto(skb) != htons(ETH_P_IP))
 		return;
 
 	ct = nf_ct_get(skb, &ctinfo);
@@ -1624,7 +1638,7 @@ static u8 cake_handle_diffserv(struct sk_buff *skb, u16 wash)
 	int wlen = skb_network_offset(skb);
 	u8 dscp;
 
-	switch (tc_skb_protocol(skb)) {
+	switch (cake_skb_proto(skb)) {
 	case htons(ETH_P_IP):
 		wlen += sizeof(struct iphdr);
 		if (!pskb_may_pull(skb, wlen) ||


### PR DESCRIPTION
tc_skb_proto() generally expands as

	if (skb_vlan_tag_present(skb))
		return skb->vlan_proto;
	return skb->protocol;

and in case of VLAN-tagged packet will return ETH_P_8021Q, but in cake_handle_diffserv() we expect only ETH_P_IP/ETH_P_IPV6, so make our own helper to extract proper values from skb.

Should be fixed in vanilla kernel also.