### PR TITLE
sch_cake: remove deprecated uninitialized_var function

### DIFF
--- a/sch_cake.c
+++ b/sch_cake.c
@@ -1809,7 +1809,7 @@ static s32 cake_enqueue(struct sk_buff *skb, struct Qdisc *sch,
 {
 	struct cake_sched_data *q = qdisc_priv(sch);
 	int len = qdisc_pkt_len(skb);
-	int uninitialized_var(ret);
+	int ret = 0;
 	struct sk_buff *ack = NULL;
 	ktime_t now = ktime_get();
 	struct cake_tin_data *b;


### PR DESCRIPTION
With the caveat that I am not a C programmer, when I went to compile this against my new kernel from Arch (5.9.8) it no longer worked. A quick search turns up the it looks like `uninitialized_var` has been intended for deprecation for a while now: https://lwn.net/Articles/529954/

Fully initializing it allows sch_cake to be able to be compiled against this new kernel and should also be safe for older kernels as well.